### PR TITLE
Add scheduling support for timers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,8 @@
 
 ## Core Features
  - [x] Timer model supporting countdown, count-up, and time-of-day
- - [ ] Manage multiple timers with presets and scheduling
+ - [x] Manage multiple timers with scheduling
+ - [ ] Timer presets for quick setup
  - [x] Basic timer management UI (add/remove)
 - [ ] Real-time sync via Firebase Firestore
 - [ ] Role-based authentication (Controller, Viewer, Moderator, Operator)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,13 @@ import Timer from './components/Timer';
 import { TimerConfig } from './types';
 
 const initialTimers: TimerConfig[] = [
-  { id: 't1', title: 'Countdown 5m', kind: 'countdown', duration: 5 * 60 * 1000 },
+  {
+    id: 't1',
+    title: 'Countdown 5m',
+    kind: 'countdown',
+    duration: 5 * 60 * 1000,
+    startAt: Date.now() + 60_000, // starts in one minute
+  },
   { id: 't2', title: 'Count Up', kind: 'countup' },
   { id: 't3', title: 'Clock', kind: 'clock' }
 ];

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -6,7 +6,11 @@ import TimerControls from './TimerControls';
 
 // Renders a single timer with display and controls
 const Timer: React.FC<{ config: TimerConfig }> = ({ config }) => {
-  const { millis, running, start, pause, reset } = useTimer(config.kind, config.duration);
+  const { millis, running, start, pause, reset } = useTimer(
+    config.kind,
+    config.duration,
+    config.startAt
+  );
 
   return (
     <div style={{ marginBottom: '2rem' }}>

--- a/src/context/TimersContext.test.ts
+++ b/src/context/TimersContext.test.ts
@@ -13,4 +13,15 @@ describe('timerReducer', () => {
     const removed = timerReducer(added, { type: 'remove', id });
     expect(removed.timers).toHaveLength(0);
   });
+
+  it('schedules a timer', () => {
+    const added = timerReducer(initialState, {
+      type: 'add',
+      payload: { title: 'Scheduled', kind: 'countdown', duration: 1000 },
+    });
+    const id = added.timers[0].id;
+    const startAt = Date.now() + 5000;
+    const scheduled = timerReducer(added, { type: 'schedule', id, startAt });
+    expect(scheduled.timers[0].startAt).toBe(startAt);
+  });
 });

--- a/src/context/TimersContext.tsx
+++ b/src/context/TimersContext.tsx
@@ -1,11 +1,17 @@
 import React, { createContext, useContext, useReducer } from 'react';
 import { TimerConfig, TimerKind } from '../types';
 
-interface AddTimerPayload { title: string; kind: TimerKind; duration?: number; }
+interface AddTimerPayload {
+  title: string;
+  kind: TimerKind;
+  duration?: number;
+  startAt?: number;
+}
 
 type Action =
   | { type: 'add'; payload: AddTimerPayload }
-  | { type: 'remove'; id: string };
+  | { type: 'remove'; id: string }
+  | { type: 'schedule'; id: string; startAt: number };
 
 export interface TimersState {
   timers: TimerConfig[];
@@ -22,11 +28,18 @@ export function timerReducer(state: TimersState, action: Action): TimersState {
         title: action.payload.title,
         kind: action.payload.kind,
         duration: action.payload.duration,
+        startAt: action.payload.startAt,
       };
       return { timers: [...state.timers, newTimer] };
     }
     case 'remove':
       return { timers: state.timers.filter((t) => t.id !== action.id) };
+    case 'schedule':
+      return {
+        timers: state.timers.map((t) =>
+          t.id === action.id ? { ...t, startAt: action.startAt } : t
+        ),
+      };
     default:
       return state;
   }

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,11 +1,23 @@
 import { useEffect, useRef, useState } from 'react';
 import { TimerKind } from '../types';
 
-// Generic timer hook supporting countdown, countup, and clock
-export const useTimer = (kind: TimerKind, duration: number = 0) => {
+// Generic timer hook supporting countdown, countup, and clock with optional scheduling
+export const useTimer = (kind: TimerKind, duration: number = 0, startAt?: number) => {
   const [elapsed, setElapsed] = useState(0);
   const [running, setRunning] = useState(false);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // start the timer at a scheduled time if provided
+  useEffect(() => {
+    if (startAt === undefined || running) return;
+    const now = Date.now();
+    if (startAt <= now) {
+      setRunning(true);
+    } else {
+      const timeout = setTimeout(() => setRunning(true), startAt - now);
+      return () => clearTimeout(timeout);
+    }
+  }, [startAt, running]);
 
   useEffect(() => {
     if (!running || kind === 'clock') return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,4 +5,5 @@ export interface TimerConfig {
   title: string;
   kind: TimerKind;
   duration?: number; // used for countdown timers
+  startAt?: number; // optional start time in ms for scheduling
 }


### PR DESCRIPTION
## Summary
- add optional start time to timer configurations
- allow scheduling timers and update reducer/tests
- auto-start timers at scheduled times via enhanced hook

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b330bd9e288328a6e3f1b4c2bdebaa