### PR TITLE
feat: add Firestore timer synchronization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 - [x] Timer presets for quick setup
 - [x] Basic timer management UI (add/remove)
 - [x] Internationalization (i18n) and localization (l10n)
-- [ ] Real-time sync via Firebase Firestore
+- [x] Real-time sync via Firebase Firestore
 - [ ] Role-based authentication (Controller, Viewer, Moderator, Operator)
 - [ ] Role-based links and QR code sharing
 - [ ] Messaging system with presets and placeholders

--- a/src/context/TimersContext.tsx
+++ b/src/context/TimersContext.tsx
@@ -6,12 +6,14 @@ export interface AddTimerPayload {
   kind: TimerKind;
   duration?: number;
   startAt?: number;
+  id?: string;
 }
 
 type Action =
   | { type: 'add'; payload: AddTimerPayload }
   | { type: 'remove'; id: string }
-  | { type: 'schedule'; id: string; startAt: number };
+  | { type: 'schedule'; id: string; startAt: number }
+  | { type: 'setAll'; timers: TimerConfig[] };
 
 export interface TimersState {
   timers: TimerConfig[];
@@ -22,7 +24,7 @@ export const initialState: TimersState = { timers: [] };
 export function timerReducer(state: TimersState, action: Action): TimersState {
   switch (action.type) {
     case 'add': {
-      const id = Date.now().toString();
+      const id = action.payload.id || Date.now().toString();
       const newTimer: TimerConfig = {
         id,
         title: action.payload.title,
@@ -40,6 +42,8 @@ export function timerReducer(state: TimersState, action: Action): TimersState {
           t.id === action.id ? { ...t, startAt: action.startAt } : t
         ),
       };
+    case 'setAll':
+      return { timers: action.timers };
     default:
       return state;
   }
@@ -51,7 +55,47 @@ const TimersContext = createContext<{
 }>({ state: initialState, dispatch: () => {} });
 
 export const TimersProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [state, dispatch] = useReducer(timerReducer, initialState);
+  const [state, localDispatch] = useReducer(timerReducer, initialState);
+
+  // Expose dispatch that syncs with Firestore
+  const dispatch: React.Dispatch<Action> = (action) => {
+    switch (action.type) {
+      case 'add': {
+        const id = action.payload.id || Date.now().toString();
+        localDispatch({ type: 'add', payload: { ...action.payload, id } });
+        import('../services/timerSync').then(({ saveTimer }) =>
+          saveTimer({ id, ...action.payload })
+        );
+        break;
+      }
+      case 'remove':
+        localDispatch(action);
+        import('../services/timerSync').then(({ removeTimer }) => removeTimer(action.id));
+        break;
+      case 'schedule':
+        localDispatch(action);
+        import('../services/timerSync').then(({ updateTimer }) =>
+          updateTimer(action.id, { startAt: action.startAt })
+        );
+        break;
+      default:
+        localDispatch(action);
+    }
+  };
+
+  // Listen to remote updates
+  React.useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+    import('../services/timerSync').then(({ listenTimers }) => {
+      unsubscribe = listenTimers((timers) =>
+        localDispatch({ type: 'setAll', timers })
+      );
+    });
+    return () => {
+      if (unsubscribe) unsubscribe();
+    };
+  }, []);
+
   return <TimersContext.Provider value={{ state, dispatch }}>{children}</TimersContext.Provider>;
 };
 

--- a/src/services/timerSync.ts
+++ b/src/services/timerSync.ts
@@ -1,0 +1,30 @@
+import { collection, doc, onSnapshot, setDoc, deleteDoc, updateDoc } from 'firebase/firestore';
+import { db } from './firebase';
+import { TimerConfig } from '../types';
+
+// Listen to the timers collection and invoke callback on changes
+export function listenTimers(callback: (timers: TimerConfig[]) => void) {
+  const colRef = collection(db, 'timers');
+  return onSnapshot(colRef, (snap) => {
+    const timers: TimerConfig[] = snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<TimerConfig, 'id'>) }));
+    callback(timers);
+  });
+}
+
+// Add or update a timer document
+export function saveTimer(timer: TimerConfig) {
+  const docRef = doc(db, 'timers', timer.id);
+  return setDoc(docRef, timer);
+}
+
+// Remove a timer by id
+export function removeTimer(id: string) {
+  const docRef = doc(db, 'timers', id);
+  return deleteDoc(docRef);
+}
+
+// Update specific fields of a timer
+export function updateTimer(id: string, data: Partial<TimerConfig>) {
+  const docRef = doc(db, 'timers', id);
+  return updateDoc(docRef, data);
+}


### PR DESCRIPTION
## Summary
- integrate TimersContext with Firestore for realtime timer updates
- add Firestore timer sync service
- mark realtime sync item as complete in TODO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b386d4bb0483289574c6957710cad0