### PR TITLE
Internationalize timer UI strings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,10 +8,6 @@ const TimersApp: React.FC = () => {
   const { state, dispatch } = useTimers();
   const { t, i18n } = useTranslation();
 
-
-const TimersApp: React.FC = () => {
-  const { state, dispatch } = useTimers();
-  
   return (
     <div>
       <h1>{t('title')}</h1>
@@ -20,11 +16,17 @@ const TimersApp: React.FC = () => {
         <button onClick={() => i18n.changeLanguage('es')}>{t('language.es')}</button>
       </div>
       <div>
-        {defaultPresets.map((p) => (
-          <button key={p.title} onClick={() => dispatch({ type: 'add', payload: p })}>
-            {t('addPreset', { title: p.title })}
-          </button>
-        ))}
+        {defaultPresets.map((p) => {
+          const title = t(p.titleKey);
+          return (
+            <button
+              key={p.titleKey}
+              onClick={() => dispatch({ type: 'add', payload: { ...p, title } })}
+            >
+              {t('addPreset', { title })}
+            </button>
+          );
+        })}
       </div>
       {state.timers.map((t) => (
         <Timer key={t.id} config={t} />

--- a/src/components/TimerControls.tsx
+++ b/src/components/TimerControls.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   onStart: () => void;
@@ -7,17 +8,20 @@ type Props = {
   running: boolean;
 };
 
-const TimerControls: React.FC<Props> = ({ onStart, onPause, onReset, running }) => (
-  <div style={{ marginTop: '1rem' }}>
-    {running ? (
-      <button onClick={onPause}>Pause</button>
-    ) : (
-      <button onClick={onStart}>Start</button>
-    )}
-    <button onClick={onReset} style={{ marginLeft: '0.5rem' }}>
-      Reset
-    </button>
-  </div>
-);
+const TimerControls: React.FC<Props> = ({ onStart, onPause, onReset, running }) => {
+  const { t } = useTranslation();
+  return (
+    <div style={{ marginTop: '1rem' }}>
+      {running ? (
+        <button onClick={onPause}>{t('controls.pause')}</button>
+      ) : (
+        <button onClick={onStart}>{t('controls.start')}</button>
+      )}
+      <button onClick={onReset} style={{ marginLeft: '0.5rem' }}>
+        {t('controls.reset')}
+      </button>
+    </div>
+  );
+};
 
 export default TimerControls;

--- a/src/components/TimerForm.tsx
+++ b/src/components/TimerForm.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { TimerKind } from '../types';
 import { useTimers } from '../context/TimersContext';
 
 const TimerForm: React.FC = () => {
   const { dispatch } = useTimers();
+  const { t } = useTranslation();
   const [title, setTitle] = useState('');
   const [kind, setKind] = useState<TimerKind>('countdown');
   const [duration, setDuration] = useState(60);
@@ -17,15 +19,15 @@ const TimerForm: React.FC = () => {
   return (
     <form onSubmit={onSubmit} style={{ marginBottom: '1rem' }}>
       <input
-        placeholder="Title"
+        placeholder={t('form.titlePlaceholder')}
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         required
       />
       <select value={kind} onChange={(e) => setKind(e.target.value as TimerKind)}>
-        <option value="countdown">Countdown</option>
-        <option value="countup">Count Up</option>
-        <option value="clock">Clock</option>
+        <option value="countdown">{t('form.countdown')}</option>
+        <option value="countup">{t('form.countup')}</option>
+        <option value="clock">{t('form.clock')}</option>
       </select>
       {kind === 'countdown' && (
         <input
@@ -35,7 +37,7 @@ const TimerForm: React.FC = () => {
           min={1}
         />
       )}
-      <button type="submit">Add Timer</button>
+      <button type="submit">{t('form.addTimer')}</button>
     </form>
   );
 };

--- a/src/components/TimerList.tsx
+++ b/src/components/TimerList.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useTimers } from '../context/TimersContext';
 import Timer from './Timer';
 
 const TimerList: React.FC = () => {
   const { state, dispatch } = useTimers();
+  const { t } = useTranslation();
 
   if (state.timers.length === 0) {
-    return <p>No timers added.</p>;
+    return <p>{t('timerList.empty')}</p>;
   }
 
   return (
@@ -14,7 +16,9 @@ const TimerList: React.FC = () => {
       {state.timers.map((t) => (
         <div key={t.id}>
           <Timer config={t} />
-          <button onClick={() => dispatch({ type: 'remove', id: t.id })}>Remove</button>
+          <button onClick={() => dispatch({ type: 'remove', id: t.id })}>
+            {t('timerList.remove')}
+          </button>
         </div>
       ))}
     </div>

--- a/src/context/TimersContext.test.ts
+++ b/src/context/TimersContext.test.ts
@@ -28,7 +28,10 @@ describe('timerReducer', () => {
 
   it('adds a timer from preset', () => {
     const preset = defaultPresets[0];
-    const state = timerReducer(initialState, { type: 'add', payload: preset });
-    expect(state.timers[0].title).toBe(preset.title);
+    const state = timerReducer(initialState, {
+      type: 'add',
+      payload: { ...preset, title: 'Countdown 1m' },
+    });
+    expect(state.timers[0].title).toBe('Countdown 1m');
   });
 });

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -4,5 +4,27 @@
   "language": {
     "en": "English",
     "es": "Español"
+  },
+  "form": {
+    "titlePlaceholder": "Title",
+    "countdown": "Countdown",
+    "countup": "Count Up",
+    "clock": "Clock",
+    "addTimer": "Add Timer"
+  },
+  "timerList": {
+    "empty": "No timers added.",
+    "remove": "Remove"
+  },
+  "controls": {
+    "pause": "Pause",
+    "start": "Start",
+    "reset": "Reset"
+  },
+  "preset": {
+    "countdown1m": "Countdown 1m",
+    "countdown5m": "Countdown 5m",
+    "countup": "Count Up",
+    "clock": "Clock"
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -4,5 +4,27 @@
   "language": {
     "en": "Inglés",
     "es": "Español"
+  },
+  "form": {
+    "titlePlaceholder": "Título",
+    "countdown": "Cuenta regresiva",
+    "countup": "Conteo ascendente",
+    "clock": "Reloj",
+    "addTimer": "Agregar temporizador"
+  },
+  "timerList": {
+    "empty": "No hay temporizadores.",
+    "remove": "Eliminar"
+  },
+  "controls": {
+    "pause": "Pausar",
+    "start": "Iniciar",
+    "reset": "Reiniciar"
+  },
+  "preset": {
+    "countdown1m": "Cuenta regresiva 1m",
+    "countdown5m": "Cuenta regresiva 5m",
+    "countup": "Conteo ascendente",
+    "clock": "Reloj"
   }
 }

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,9 +1,11 @@
 import { AddTimerPayload } from './context/TimersContext';
 
+export type Preset = Omit<AddTimerPayload, 'title'> & { titleKey: string };
+
 // Default timer presets for quick setup
-export const defaultPresets: AddTimerPayload[] = [
-  { title: 'Countdown 1m', kind: 'countdown', duration: 60_000 },
-  { title: 'Countdown 5m', kind: 'countdown', duration: 5 * 60_000 },
-  { title: 'Count Up', kind: 'countup' },
-  { title: 'Clock', kind: 'clock' },
+export const defaultPresets: Preset[] = [
+  { titleKey: 'preset.countdown1m', kind: 'countdown', duration: 60_000 },
+  { titleKey: 'preset.countdown5m', kind: 'countdown', duration: 5 * 60_000 },
+  { titleKey: 'preset.countup', kind: 'countup' },
+  { titleKey: 'preset.clock', kind: 'clock' },
 ];


### PR DESCRIPTION
## Summary
- Use translation keys for timer presets
- Replace hardcoded timer form, list, and control labels with i18n lookups
- Expand English and Spanish locale files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3894e2d188328a19594fec0a57782