### PR TITLE
feat: add role-based auth context

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 - [x] Basic timer management UI (add/remove)
 - [x] Internationalization (i18n) and localization (l10n)
 - [x] Real-time sync via Firebase Firestore
-- [ ] Role-based authentication (Controller, Viewer, Moderator, Operator)
+- [x] Role-based authentication (Controller, Viewer, Moderator, Operator)
 - [ ] Role-based links and QR code sharing
 - [ ] Messaging system with presets and placeholders
 - [ ] CSV import/export for timers

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Timer from './components/Timer';
 import { TimersProvider, useTimers } from './context/TimersContext';
+import { AuthProvider } from './context/AuthContext';
 import { defaultPresets } from './presets';
 import { useTranslation } from 'react-i18next';
 
@@ -36,9 +37,11 @@ const TimersApp: React.FC = () => {
 };
 
 const App: React.FC = () => (
-  <TimersProvider>
-    <TimersApp />
-  </TimersProvider>
+  <AuthProvider>
+    <TimersProvider>
+      <TimersApp />
+    </TimersProvider>
+  </AuthProvider>
 );
 
 export default App;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { User } from 'firebase/auth';
+import { auth } from '../services/firebase';
+import { getUserRole } from '../services/auth';
+import type { Role } from '../types';
+
+interface AuthContextValue {
+  user: User | null;
+  role: Role | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  role: null,
+  loading: true,
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [role, setRole] = useState<Role | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged(async (u) => {
+      setUser(u);
+      if (u) {
+        const r = await getUserRole(u);
+        setRole(r);
+      } else {
+        setRole(null);
+      }
+      setLoading(false);
+    });
+    return unsubscribe;
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, role, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+// Convenience hook to check if current user has required role
+export function useHasRole(required: Role | Role[]): boolean {
+  const { role, loading } = useAuth();
+  if (loading || !role) return false;
+  const roles = Array.isArray(required) ? required : [required];
+  return roles.includes(role);
+}

--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -1,0 +1,61 @@
+import { getUserRole, login, logout } from './auth';
+import { getDoc, doc } from 'firebase/firestore';
+import { signInWithEmailAndPassword, signOut } from 'firebase/auth';
+
+jest.mock('./firebase', () => ({
+  db: {},
+  auth: {},
+}));
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+}));
+
+jest.mock('firebase/auth', () => ({
+  signInWithEmailAndPassword: jest.fn(),
+  signOut: jest.fn(),
+}));
+
+describe('getUserRole', () => {
+  it('returns role from firestore', async () => {
+    (getDoc as jest.Mock).mockResolvedValue({
+      exists: () => true,
+      data: () => ({ role: 'viewer' }),
+    });
+    const role = await getUserRole({ uid: 'u1' } as any);
+    expect(role).toBe('viewer');
+    expect(doc).toHaveBeenCalledWith(expect.anything(), 'users', 'u1');
+  });
+
+  it('returns null when doc missing', async () => {
+    (getDoc as jest.Mock).mockResolvedValue({ exists: () => false });
+    const role = await getUserRole({ uid: 'u2' } as any);
+    expect(role).toBeNull();
+  });
+});
+
+describe('auth helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('login signs in and fetches role', async () => {
+    (signInWithEmailAndPassword as jest.Mock).mockResolvedValue({
+      user: { uid: 'u3' },
+    });
+    (getDoc as jest.Mock).mockResolvedValue({
+      exists: () => true,
+      data: () => ({ role: 'controller' }),
+    });
+    const result = await login('a@example.com', 'pw');
+    expect(signInWithEmailAndPassword).toHaveBeenCalledWith(expect.anything(), 'a@example.com', 'pw');
+    expect(result.role).toBe('controller');
+  });
+
+  it('logout signs out', async () => {
+    (signOut as jest.Mock).mockResolvedValue(undefined);
+    await logout();
+    expect(signOut).toHaveBeenCalled();
+  });
+});

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,27 @@
+import { signInWithEmailAndPassword, signOut, User } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+import { auth, db } from './firebase';
+import type { Role } from '../types';
+
+// Fetches the role for a user from Firestore `users/{uid}` document
+export async function getUserRole(user: User): Promise<Role | null> {
+  const snap = await getDoc(doc(db, 'users', user.uid));
+  if (!snap.exists()) return null;
+  const data = snap.data() as { role?: Role };
+  return data.role ?? null;
+}
+
+// Signs in the user and returns the role
+export async function login(
+  email: string,
+  password: string
+): Promise<{ user: User; role: Role | null }> {
+  const cred = await signInWithEmailAndPassword(auth, email, password);
+  const role = await getUserRole(cred.user);
+  return { user: cred.user, role };
+}
+
+// Signs out the current user
+export function logout() {
+  return signOut(auth);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
 export type TimerKind = 'countdown' | 'countup' | 'clock';
 
+// Role-based authentication roles
+export type Role = 'controller' | 'viewer' | 'moderator' | 'operator';
+
 export interface TimerConfig {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- define user roles and implement Firebase auth service
- introduce AuthContext and enhance `useHasRole` to handle multiple roles
- expand auth service tests and update TODO checklist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38beef4288328a94e851ec190b78c