### PR TITLE
Add role-based links and QR code sharing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 - [x] Internationalization (i18n) and localization (l10n)
 - [x] Real-time sync via Firebase Firestore
 - [x] Role-based authentication (Controller, Viewer, Moderator, Operator)
-- [ ] Role-based links and QR code sharing
+- [x] Role-based links and QR code sharing
 - [ ] Messaging system with presets and placeholders
 - [ ] CSV import/export for timers
 - [ ] Device list with heartbeats and logs export

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "i18next": "^25.4.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-i18next": "^15.7.3"
+        "react-i18next": "^15.7.3",
+        "react-qr-code": "^2.0.18"
       },
       "devDependencies": {
         "@types/jest": "^29.5.5",
@@ -4311,6 +4312,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4562,6 +4572,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -4601,6 +4628,12 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
       "license": "MIT"
     },
     "node_modules/react": {
@@ -4660,6 +4693,19 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.18.tgz",
+      "integrity": "sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "i18next": "^25.4.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-i18next": "^15.7.3"
+    "react-i18next": "^15.7.3",
+    "react-qr-code": "^2.0.18"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",

--- a/src/components/RoleLinks.tsx
+++ b/src/components/RoleLinks.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import QRCode from 'react-qr-code';
+import { Role } from '../types';
+
+const roles: Role[] = ['controller', 'viewer', 'moderator', 'operator'];
+
+// Displays shareable links and QR codes for each role
+const RoleLinks: React.FC = () => {
+  return (
+    <div>
+      <h2>Share Links</h2>
+      {roles.map((role) => {
+        const url = `${window.location.origin}/${role}`;
+        return (
+          <div key={role} style={{ marginBottom: '1rem' }}>
+            <h3>{role}</h3>
+            <a href={url}>{url}</a>
+            <div style={{ height: 128, marginTop: 8 }}>
+              <QRCode value={url} size={128} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default RoleLinks;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,36 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
 import './i18n';
+import Controller from './pages/Controller';
+import Viewer from './pages/Viewer';
+import Moderator from './pages/Moderator';
+import Operator from './pages/Operator';
+import RoleLinks from './components/RoleLinks';
+import { AuthProvider } from './context/AuthContext';
+import { TimersProvider } from './context/TimersContext';
+
+const path = window.location.pathname.replace(/\/$/, '').toLowerCase();
+
+const getComponent = (): React.ReactElement => {
+  switch (path) {
+    case '/controller':
+      return <Controller />;
+    case '/viewer':
+      return <Viewer />;
+    case '/moderator':
+      return <Moderator />;
+    case '/operator':
+      return <Operator />;
+    default:
+      return <RoleLinks />;
+  }
+};
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <TimersProvider>{getComponent()}</TimersProvider>
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/src/pages/Moderator.tsx
+++ b/src/pages/Moderator.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// Moderator page placeholder
+const Moderator: React.FC = () => {
+  return <div>Moderator Page</div>;
+};
+
+export default Moderator;

--- a/src/pages/Operator.tsx
+++ b/src/pages/Operator.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// Operator page placeholder
+const Operator: React.FC = () => {
+  return <div>Operator Page</div>;
+};
+
+export default Operator;


### PR DESCRIPTION
## Summary
- Generate shareable URLs and QR codes for controller, viewer, moderator, and operator roles.
- Route application based on URL path to show each role's page, including new moderator and operator placeholders.
- Add `react-qr-code` dependency and mark TODO item completed.

## Testing
- `npm test`
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_68b391fa117c8328b705023953d80633