### PR TITLE
feat: add messaging with internationalized presets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Timer from './components/Timer';
 import { TimersProvider, useTimers } from './context/TimersContext';
 import { AuthProvider } from './context/AuthContext';
+import { MessagesProvider } from './context/MessagesContext';
+import Messages from './components/Messages';
 import { defaultPresets } from './presets';
 import { useTranslation } from 'react-i18next';
 
@@ -32,6 +34,7 @@ const TimersApp: React.FC = () => {
       {state.timers.map((t) => (
         <Timer key={t.id} config={t} />
       ))}
+      <Messages />
     </div>
   );
 };
@@ -39,7 +42,9 @@ const TimersApp: React.FC = () => {
 const App: React.FC = () => (
   <AuthProvider>
     <TimersProvider>
-      <TimersApp />
+      <MessagesProvider>
+        <TimersApp />
+      </MessagesProvider>
     </TimersProvider>
   </AuthProvider>
 );

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useMessages } from '../context/MessagesContext';
+import { messagePresets, MessagePreset } from '../messagePresets';
+import { useTranslation } from 'react-i18next';
+
+const Messages: React.FC = () => {
+  const { state, send, clear } = useMessages();
+  const { t } = useTranslation();
+
+  const handlePreset = (preset: MessagePreset) => {
+    let values: Record<string, string> | undefined;
+    if (preset.placeholders) {
+      values = {};
+      for (const ph of preset.placeholders) {
+        const v = window.prompt(t(`messages.placeholder.${ph}`) || ph, '');
+        if (v) values[ph] = v;
+      }
+    }
+    const text = t(preset.key, values);
+    send(text);
+  };
+
+  return (
+    <div>
+      <h2>{t('messages.title')}</h2>
+      <div>
+        {messagePresets.map((p) => {
+          const defaults: Record<string, string> = {};
+          p.placeholders?.forEach((ph) => {
+            defaults[ph] = t(`messages.placeholder.${ph}`);
+          });
+          return (
+            <button key={p.key} onClick={() => handlePreset(p)}>
+              {t(p.key, defaults)}
+            </button>
+          );
+        })}
+        <button onClick={clear}>{t('messages.clear')}</button>
+      </div>
+      {state.current && <p>{state.current.text}</p>}
+    </div>
+  );
+};
+
+export default Messages;

--- a/src/context/MessagesContext.tsx
+++ b/src/context/MessagesContext.tsx
@@ -1,0 +1,66 @@
+import React, { createContext, useContext, useReducer, useEffect } from 'react';
+import { Message } from '../types';
+
+interface State {
+  current: Message | null;
+}
+
+const initialState: State = { current: null };
+
+type Action = { type: 'set'; message: Message | null };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'set':
+      return { current: action.message };
+    default:
+      return state;
+  }
+}
+
+interface ContextValue {
+  state: State;
+  send: (text: string) => void;
+  clear: () => void;
+}
+
+const MessagesContext = createContext<ContextValue>({
+  state: initialState,
+  send: () => {},
+  clear: () => {},
+});
+
+export const MessagesProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const send = (text: string) => {
+    const message: Message = { text, createdAt: Date.now() };
+    dispatch({ type: 'set', message });
+    import('../services/messageSync').then(({ sendMessage }) => sendMessage(message));
+  };
+
+  const clear = () => {
+    dispatch({ type: 'set', message: null });
+    import('../services/messageSync').then(({ clearMessage }) => clearMessage());
+  };
+
+  useEffect(() => {
+    let unsub: (() => void) | undefined;
+    import('../services/messageSync').then(({ listenMessage }) => {
+      unsub = listenMessage((msg) => dispatch({ type: 'set', message: msg }));
+    });
+    return () => {
+      if (unsub) unsub();
+    };
+  }, []);
+
+  return (
+    <MessagesContext.Provider value={{ state, send, clear }}>
+      {children}
+    </MessagesContext.Provider>
+  );
+};
+
+export function useMessages() {
+  return useContext(MessagesContext);
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -26,5 +26,16 @@
     "countdown5m": "Countdown 5m",
     "countup": "Count Up",
     "clock": "Clock"
+  },
+  "messages": {
+    "title": "Messages",
+    "clear": "Clear",
+    "preset": {
+      "break": "Take a short break",
+      "next": "Next up: {{name}}"
+    },
+    "placeholder": {
+      "name": "Name"
+    }
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -26,5 +26,16 @@
     "countdown5m": "Cuenta regresiva 5m",
     "countup": "Conteo ascendente",
     "clock": "Reloj"
+  },
+  "messages": {
+    "title": "Mensajes",
+    "clear": "Limpiar",
+    "preset": {
+      "break": "Tómate un descanso",
+      "next": "A continuación: {{name}}"
+    },
+    "placeholder": {
+      "name": "Nombre"
+    }
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import Operator from './pages/Operator';
 import RoleLinks from './components/RoleLinks';
 import { AuthProvider } from './context/AuthContext';
 import { TimersProvider } from './context/TimersContext';
+import { MessagesProvider } from './context/MessagesContext';
 
 const path = window.location.pathname.replace(/\/$/, '').toLowerCase();
 
@@ -30,7 +31,9 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
     <AuthProvider>
-      <TimersProvider>{getComponent()}</TimersProvider>
+      <TimersProvider>
+        <MessagesProvider>{getComponent()}</MessagesProvider>
+      </TimersProvider>
     </AuthProvider>
   </React.StrictMode>
 );

--- a/src/messagePresets.test.ts
+++ b/src/messagePresets.test.ts
@@ -1,0 +1,14 @@
+import './i18n';
+import i18n from 'i18next';
+
+describe('message presets i18n', () => {
+  it('translates next message with placeholder in English', () => {
+    i18n.changeLanguage('en');
+    expect(i18n.t('messages.preset.next', { name: 'Alice' })).toBe('Next up: Alice');
+  });
+
+  it('translates next message with placeholder in Spanish', () => {
+    i18n.changeLanguage('es');
+    expect(i18n.t('messages.preset.next', { name: 'Carlos' })).toBe('A continuación: Carlos');
+  });
+});

--- a/src/messagePresets.ts
+++ b/src/messagePresets.ts
@@ -1,0 +1,10 @@
+export interface MessagePreset {
+  key: string;
+  placeholders?: string[];
+}
+
+// Preset messages with optional placeholders
+export const messagePresets: MessagePreset[] = [
+  { key: 'messages.preset.break' },
+  { key: 'messages.preset.next', placeholders: ['name'] },
+];

--- a/src/pages/Moderator.tsx
+++ b/src/pages/Moderator.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import Messages from '../components/Messages';
 
-// Moderator page placeholder
+// Moderator page renders messaging controls
 const Moderator: React.FC = () => {
-  return <div>Moderator Page</div>;
+  return (
+    <div>
+      <Messages />
+    </div>
+  );
 };
 
 export default Moderator;

--- a/src/pages/Viewer.tsx
+++ b/src/pages/Viewer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import TimerDisplay from '../components/TimerDisplay';
+import { useMessages } from '../context/MessagesContext';
 
 // Viewer page listens to updates (placeholder without backend)
 const Viewer: React.FC = () => {
@@ -11,7 +12,14 @@ const Viewer: React.FC = () => {
     return () => clearInterval(id);
   }, []);
 
-  return <TimerDisplay millis={time} />;
+  const { state } = useMessages();
+
+  return (
+    <div>
+      <TimerDisplay millis={time} />
+      {state.current && <p>{state.current.text}</p>}
+    </div>
+  );
 };
 
 export default Viewer;

--- a/src/services/messageSync.ts
+++ b/src/services/messageSync.ts
@@ -1,0 +1,19 @@
+import { doc, onSnapshot, setDoc, deleteDoc } from 'firebase/firestore';
+import { db } from './firebase';
+import { Message } from '../types';
+
+const docRef = doc(db, 'messages', 'current');
+
+export function listenMessage(callback: (msg: Message | null) => void) {
+  return onSnapshot(docRef, (snap) => {
+    callback(snap.exists() ? (snap.data() as Message) : null);
+  });
+}
+
+export function sendMessage(message: Message) {
+  return setDoc(docRef, message);
+}
+
+export function clearMessage() {
+  return deleteDoc(docRef);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,9 @@ export interface TimerConfig {
   duration?: number; // used for countdown timers
   startAt?: number; // optional start time in ms for scheduling
 }
+
+// Simple message structure for messaging system
+export interface Message {
+  text: string;
+  createdAt: number;
+}


### PR DESCRIPTION
## Summary
- add messaging context and Firestore sync
- provide preset messages with placeholder prompts
- localize messaging UI and presets in English and Spanish

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b39fcaff708328a13706d8ed6e00bf