### PR TITLE
feat: add timer import/export

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 - [x] Role-based authentication (Controller, Viewer, Moderator, Operator)
 - [x] Role-based links and QR code sharing
 - [ ] Messaging system with presets and placeholders
-- [ ] CSV import/export for timers
+- [x] CSV import/export for timers
 - [ ] Device list with heartbeats and logs export
 
 ## Customization

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-qr-code": "^2.0.18"
       },
       "devDependencies": {
+        "@types/i18next": "^12.1.0",
         "@types/jest": "^29.5.5",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
@@ -2055,6 +2056,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/i18next": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@types/i18next/-/i18next-12.1.0.tgz",
+      "integrity": "sha512-qLyqTkp3ZKHsSoX8CNVYcTyTkxlm0aRCUpaUVetgkSlSpiNCdWryOgaYwgbO04tJIfLgBXPcy0tJ3Nl/RagllA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-qr-code": "^2.0.18"
   },
   "devDependencies": {
+    "@types/i18next": "^12.1.0",
     "@types/jest": "^29.5.5",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import Timer from './components/Timer';
 import { TimersProvider, useTimers } from './context/TimersContext';
 import { AuthProvider } from './context/AuthContext';
 import { MessagesProvider } from './context/MessagesContext';
 import Messages from './components/Messages';
 import { defaultPresets } from './presets';
 import { useTranslation } from 'react-i18next';
+import TimerForm from './components/TimerForm';
+import TimerList from './components/TimerList';
+import TimerImportExport from './components/TimerImportExport';
 
 const TimersApp: React.FC = () => {
-  const { state, dispatch } = useTimers();
+  const { dispatch } = useTimers();
   const { t, i18n } = useTranslation();
 
   return (
@@ -31,9 +33,9 @@ const TimersApp: React.FC = () => {
           );
         })}
       </div>
-      {state.timers.map((t) => (
-        <Timer key={t.id} config={t} />
-      ))}
+      <TimerForm />
+      <TimerList />
+      <TimerImportExport />
       <Messages />
     </div>
   );

--- a/src/components/TimerImportExport.tsx
+++ b/src/components/TimerImportExport.tsx
@@ -1,0 +1,62 @@
+import React, { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useTimers } from '../context/TimersContext';
+import { exportTimers, importTimers } from '../utils/timerIO';
+
+const TimerImportExport: React.FC = () => {
+  const { state, dispatch } = useTimers();
+  const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleExport = (format: 'json' | 'csv') => {
+    const data = exportTimers(state.timers, format);
+    const blob = new Blob([data], {
+      type: format === 'json' ? 'application/json' : 'text/csv',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `timers.${format}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const onImportChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const text = ev.target?.result as string;
+        const ext = file.name.split('.').pop()?.toLowerCase();
+        const format = ext === 'csv' ? 'csv' : 'json';
+        const timers = importTimers(text, format);
+        dispatch({ type: 'setAll', timers });
+      } catch (err) {
+        console.error(err);
+        alert(t('timerList.importError'));
+      }
+    };
+    reader.readAsText(file);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  return (
+    <div>
+      <button onClick={() => handleExport('json')}>{t('timerList.exportJson')}</button>
+      <button onClick={() => handleExport('csv')}>{t('timerList.exportCsv')}</button>
+      <button onClick={() => fileInputRef.current?.click()}>{t('timerList.import')}</button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json,.csv"
+        style={{ display: 'none' }}
+        onChange={onImportChange}
+      />
+    </div>
+  );
+};
+
+export default TimerImportExport;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -14,7 +14,11 @@
   },
   "timerList": {
     "empty": "No timers added.",
-    "remove": "Remove"
+    "remove": "Remove",
+    "exportJson": "Export JSON",
+    "exportCsv": "Export CSV",
+    "import": "Import",
+    "importError": "Failed to import timers"
   },
   "controls": {
     "pause": "Pause",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -14,7 +14,11 @@
   },
   "timerList": {
     "empty": "No hay temporizadores.",
-    "remove": "Eliminar"
+    "remove": "Eliminar",
+    "exportJson": "Exportar JSON",
+    "exportCsv": "Exportar CSV",
+    "import": "Importar",
+    "importError": "Error al importar temporizadores"
   },
   "controls": {
     "pause": "Pausar",

--- a/src/utils/timerIO.test.ts
+++ b/src/utils/timerIO.test.ts
@@ -1,0 +1,30 @@
+import { exportTimers, importTimers } from './timerIO';
+import { TimerConfig } from '../types';
+
+describe('timerIO', () => {
+  const timers: TimerConfig[] = [
+    { id: '1', title: 'A', kind: 'countdown', duration: 1000 },
+    { id: '2', title: 'B', kind: 'countup' },
+  ];
+
+  it('exports and imports JSON', () => {
+    const data = exportTimers(timers, 'json');
+    const parsed = importTimers(data, 'json');
+    expect(parsed).toEqual(timers);
+  });
+
+  it('exports and imports CSV', () => {
+    const data = exportTimers(timers, 'csv');
+    const parsed = importTimers(data, 'csv');
+    expect(parsed).toEqual(timers);
+  });
+
+  it('handles commas and quotes in CSV titles', () => {
+    const funky: TimerConfig[] = [
+      { id: '3', title: 'Hello, "World"', kind: 'countdown', duration: 5000 },
+    ];
+    const data = exportTimers(funky, 'csv');
+    const parsed = importTimers(data, 'csv');
+    expect(parsed).toEqual(funky);
+  });
+});

--- a/src/utils/timerIO.ts
+++ b/src/utils/timerIO.ts
@@ -1,0 +1,82 @@
+import { TimerConfig, TimerKind } from '../types';
+
+// Export timers to specified format
+export function exportTimers(timers: TimerConfig[], format: 'json' | 'csv'): string {
+  if (format === 'json') {
+    return JSON.stringify(timers, null, 2);
+  }
+  const header = 'id,title,kind,duration,startAt';
+  const rows = timers.map((t) =>
+    [
+      t.id,
+      escapeCsv(t.title),
+      t.kind,
+      t.duration ?? '',
+      t.startAt ?? '',
+    ].join(',')
+  );
+  return [header, ...rows].join('\n');
+}
+
+// Import timers from given data
+export function importTimers(data: string, format: 'json' | 'csv'): TimerConfig[] {
+  if (format === 'json') {
+    const arr = JSON.parse(data);
+    return Array.isArray(arr) ? arr.map(normalizeTimer) : [];
+  }
+  const lines = data.trim().split(/\r?\n/);
+  const [, ...rows] = lines; // skip header
+  return rows.filter(Boolean).map((line) => {
+    const [id, title, kind, duration, startAt] = parseCsvLine(line);
+    return normalizeTimer({ id, title, kind, duration, startAt });
+  });
+}
+
+function normalizeTimer(obj: any): TimerConfig {
+  return {
+    id: String(obj.id),
+    title: String(obj.title),
+    kind: obj.kind as TimerKind,
+    duration: obj.duration !== undefined && obj.duration !== '' ? Number(obj.duration) : undefined,
+    startAt: obj.startAt !== undefined && obj.startAt !== '' ? Number(obj.startAt) : undefined,
+  };
+}
+
+function escapeCsv(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return '"' + value.replace(/"/g, '""') + '"';
+  }
+  return value;
+}
+
+function parseCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ',') {
+        result.push(current);
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+  }
+  result.push(current);
+  return result;
+}


### PR DESCRIPTION
## Summary
- add utilities to import/export timers in json and csv
- add UI component for exporting to JSON/CSV and importing timer files
- wire import/export into main app and translations
- cover CSV export/import edge cases with commas and quotes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a649190883289e9a0de89da7cdcb