### PR TITLE
Add device heartbeats and logs export

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,9 +9,9 @@
 - [x] Real-time sync via Firebase Firestore
 - [x] Role-based authentication (Controller, Viewer, Moderator, Operator)
 - [x] Role-based links and QR code sharing
-- [ ] Messaging system with presets and placeholders
+- [x] Messaging system with presets and placeholders
 - [x] CSV import/export for timers
-- [ ] Device list with heartbeats and logs export
+- [x] Device list with heartbeats and logs export
 
 ## Customization
 - [ ] Themes (colors, fonts, backgrounds)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { TimersProvider, useTimers } from './context/TimersContext';
 import { AuthProvider } from './context/AuthContext';
 import { MessagesProvider } from './context/MessagesContext';
@@ -8,10 +8,16 @@ import { useTranslation } from 'react-i18next';
 import TimerForm from './components/TimerForm';
 import TimerList from './components/TimerList';
 import TimerImportExport from './components/TimerImportExport';
+import DeviceList from './components/DeviceList';
+import { initHeartbeat } from './services/deviceSync';
 
 const TimersApp: React.FC = () => {
   const { dispatch } = useTimers();
   const { t, i18n } = useTranslation();
+
+  useEffect(() => {
+    initHeartbeat();
+  }, []);
 
   return (
     <div>
@@ -37,6 +43,7 @@ const TimersApp: React.FC = () => {
       <TimerList />
       <TimerImportExport />
       <Messages />
+      <DeviceList />
     </div>
   );
 };

--- a/src/components/DeviceList.tsx
+++ b/src/components/DeviceList.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { listenDevices, exportLogs } from '../services/deviceSync';
+import { Device } from '../types';
+import { useTranslation } from 'react-i18next';
+
+const DeviceList: React.FC = () => {
+  const [devices, setDevices] = useState<Device[]>([]);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const unsub = listenDevices(setDevices);
+    return () => unsub();
+  }, []);
+
+  return (
+    <div>
+      <h2>{t('devices.title')}</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>{t('devices.id')}</th>
+            <th>{t('devices.lastSeen')}</th>
+            <th>{t('devices.logs')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {devices.map((d) => (
+            <tr key={d.id}>
+              <td>{d.id}</td>
+              <td>{new Date(d.lastSeen).toLocaleString()}</td>
+              <td>
+                <button onClick={() => exportLogs(d)}>{t('devices.export')}</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default DeviceList;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -41,5 +41,12 @@
     "placeholder": {
       "name": "Name"
     }
+  },
+  "devices": {
+    "title": "Devices",
+    "id": "ID",
+    "lastSeen": "Last heartbeat",
+    "logs": "Logs",
+    "export": "Export logs"
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -41,5 +41,12 @@
     "placeholder": {
       "name": "Nombre"
     }
+  },
+  "devices": {
+    "title": "Dispositivos",
+    "id": "ID",
+    "lastSeen": "Última señal",
+    "logs": "Registros",
+    "export": "Exportar registros"
   }
 }

--- a/src/services/deviceSync.ts
+++ b/src/services/deviceSync.ts
@@ -1,0 +1,49 @@
+import { collection, doc, onSnapshot, setDoc, arrayUnion } from 'firebase/firestore';
+import { db } from './firebase';
+import { Device } from '../types';
+
+const devicesCol = collection(db, 'devices');
+
+export function listenDevices(callback: (devices: Device[]) => void) {
+  return onSnapshot(devicesCol, (snap) => {
+    const devices = snap.docs.map((d) => d.data() as Device);
+    callback(devices);
+  });
+}
+
+export async function sendHeartbeat(deviceId: string) {
+  const ref = doc(devicesCol, deviceId);
+  const now = Date.now();
+  await setDoc(
+    ref,
+    { id: deviceId, lastSeen: now, logs: arrayUnion({ ts: now, event: 'heartbeat' }) },
+    { merge: true }
+  );
+}
+
+export function startHeartbeat(deviceId: string, interval = 30000) {
+  sendHeartbeat(deviceId);
+  return setInterval(() => sendHeartbeat(deviceId), interval);
+}
+
+export function initHeartbeat() {
+  let id = localStorage.getItem('deviceId');
+  if (!id) {
+    id = Math.random().toString(36).slice(2);
+    localStorage.setItem('deviceId', id);
+  }
+  startHeartbeat(id);
+}
+
+export function exportLogs(device: Device) {
+  const rows = device.logs?.map((l) => `${new Date(l.ts).toISOString()},${l.event}`) || [];
+  const header = 'timestamp,event';
+  const csv = [header, ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${device.id}-logs.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,3 +16,15 @@ export interface Message {
   text: string;
   createdAt: number;
 }
+
+// Device structure for heartbeat tracking and logs
+export interface DeviceLog {
+  ts: number;
+  event: string;
+}
+
+export interface Device {
+  id: string;
+  lastSeen: number;
+  logs?: DeviceLog[];
+}


### PR DESCRIPTION
## Summary
- track devices in Firestore with periodic heartbeats and log history
- display connected devices and allow per-device log export
- mark messaging system and device tracking tasks complete in TODO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3ac241c9483289ba4465592a8c98a