### PR TITLE
feat: add theme and viewer customization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,8 +14,8 @@
 - [x] Device list with heartbeats and logs export
 
 ## Customization
-- [ ] Themes (colors, fonts, backgrounds)
-- [ ] Viewer options: progress bar, toggle fields, mirror mode
+- [x] Themes (colors, fonts, backgrounds)
+- [x] Viewer options: progress bar, toggle fields, mirror mode
 
 ## Integrations
 - [ ] HTTP API endpoints for timer control

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import TimerList from './components/TimerList';
 import TimerImportExport from './components/TimerImportExport';
 import DeviceList from './components/DeviceList';
 import { initHeartbeat } from './services/deviceSync';
+import CustomizationPanel from './components/CustomizationPanel';
 
 const TimersApp: React.FC = () => {
   const { dispatch } = useTimers();
@@ -44,6 +45,7 @@ const TimersApp: React.FC = () => {
       <TimerImportExport />
       <Messages />
       <DeviceList />
+      <CustomizationPanel />
     </div>
   );
 };

--- a/src/components/CustomizationPanel.tsx
+++ b/src/components/CustomizationPanel.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { useCustomization } from '../context/CustomizationContext';
+
+const CustomizationPanel: React.FC = () => {
+  const { state, dispatch } = useCustomization();
+
+  return (
+    <div style={{ marginTop: '1rem' }}>
+      <h3>Customization</h3>
+      <div>
+        <label>
+          Theme Color:
+          <input
+            type="color"
+            value={state.themeColor}
+            onChange={(e) => dispatch({ type: 'setThemeColor', color: e.target.value })}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Background Color:
+          <input
+            type="color"
+            value={state.backgroundColor}
+            onChange={(e) => dispatch({ type: 'setBackgroundColor', color: e.target.value })}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Font Family:
+          <input
+            type="text"
+            value={state.fontFamily}
+            onChange={(e) => dispatch({ type: 'setFontFamily', font: e.target.value })}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={state.showProgressBar}
+            onChange={() => dispatch({ type: 'toggleProgressBar' })}
+          />
+          Show Progress Bar
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={state.showTimer}
+            onChange={() => dispatch({ type: 'toggleTimer' })}
+          />
+          Show Timer
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={state.showMessage}
+            onChange={() => dispatch({ type: 'toggleMessage' })}
+          />
+          Show Message
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={state.mirror}
+            onChange={() => dispatch({ type: 'toggleMirror' })}
+          />
+          Mirror Mode
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default CustomizationPanel;
+

--- a/src/components/TimerDisplay.tsx
+++ b/src/components/TimerDisplay.tsx
@@ -1,12 +1,25 @@
 import React from 'react';
 import { formatTime } from '../utils/time';
+import { useCustomization } from '../context/CustomizationContext';
 
 type Props = {
   millis: number;
 };
 
 const TimerDisplay: React.FC<Props> = ({ millis }) => {
-  return <div style={{ fontSize: '4rem', fontFamily: 'monospace' }}>{formatTime(millis)}</div>;
+  const { state } = useCustomization();
+
+  return (
+    <div
+      style={{
+        fontSize: '4rem',
+        fontFamily: state.fontFamily,
+        color: state.themeColor,
+      }}
+    >
+      {formatTime(millis)}
+    </div>
+  );
 };
 
 export default TimerDisplay;

--- a/src/context/CustomizationContext.test.ts
+++ b/src/context/CustomizationContext.test.ts
@@ -1,0 +1,8 @@
+import { customizationReducer, defaultCustomizationState } from './CustomizationContext';
+
+describe('customizationReducer', () => {
+  it('toggles progress bar', () => {
+    const state = customizationReducer(defaultCustomizationState, { type: 'toggleProgressBar' });
+    expect(state.showProgressBar).toBe(true);
+  });
+});

--- a/src/context/CustomizationContext.tsx
+++ b/src/context/CustomizationContext.tsx
@@ -1,0 +1,74 @@
+import React, { createContext, useContext, useReducer } from 'react';
+
+export type CustomizationState = {
+  themeColor: string;
+  backgroundColor: string;
+  fontFamily: string;
+  showProgressBar: boolean;
+  showTimer: boolean;
+  showMessage: boolean;
+  mirror: boolean;
+};
+
+export type CustomizationAction =
+  | { type: 'setThemeColor'; color: string }
+  | { type: 'setBackgroundColor'; color: string }
+  | { type: 'setFontFamily'; font: string }
+  | { type: 'toggleProgressBar' }
+  | { type: 'toggleMirror' }
+  | { type: 'toggleTimer' }
+  | { type: 'toggleMessage' };
+
+export const defaultCustomizationState: CustomizationState = {
+  themeColor: '#ffffff',
+  backgroundColor: '#000000',
+  fontFamily: 'monospace',
+  showProgressBar: false,
+  showTimer: true,
+  showMessage: true,
+  mirror: false,
+};
+
+export function customizationReducer(
+  state: CustomizationState,
+  action: CustomizationAction
+): CustomizationState {
+  switch (action.type) {
+    case 'setThemeColor':
+      return { ...state, themeColor: action.color };
+    case 'setBackgroundColor':
+      return { ...state, backgroundColor: action.color };
+    case 'setFontFamily':
+      return { ...state, fontFamily: action.font };
+    case 'toggleProgressBar':
+      return { ...state, showProgressBar: !state.showProgressBar };
+    case 'toggleMirror':
+      return { ...state, mirror: !state.mirror };
+    case 'toggleTimer':
+      return { ...state, showTimer: !state.showTimer };
+    case 'toggleMessage':
+      return { ...state, showMessage: !state.showMessage };
+    default:
+      return state;
+  }
+}
+
+const CustomizationContext = createContext<{
+  state: CustomizationState;
+  dispatch: React.Dispatch<CustomizationAction>;
+}>({
+  state: defaultCustomizationState,
+  dispatch: () => {},
+});
+
+export const CustomizationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, dispatch] = useReducer(customizationReducer, defaultCustomizationState);
+  return (
+    <CustomizationContext.Provider value={{ state, dispatch }}>
+      {children}
+    </CustomizationContext.Provider>
+  );
+};
+
+export const useCustomization = () => useContext(CustomizationContext);
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import RoleLinks from './components/RoleLinks';
 import { AuthProvider } from './context/AuthContext';
 import { TimersProvider } from './context/TimersContext';
 import { MessagesProvider } from './context/MessagesContext';
+import { CustomizationProvider } from './context/CustomizationContext';
 
 const path = window.location.pathname.replace(/\/$/, '').toLowerCase();
 
@@ -32,7 +33,9 @@ root.render(
   <React.StrictMode>
     <AuthProvider>
       <TimersProvider>
-        <MessagesProvider>{getComponent()}</MessagesProvider>
+        <MessagesProvider>
+          <CustomizationProvider>{getComponent()}</CustomizationProvider>
+        </MessagesProvider>
       </TimersProvider>
     </AuthProvider>
   </React.StrictMode>

--- a/src/pages/Viewer.tsx
+++ b/src/pages/Viewer.tsx
@@ -1,23 +1,58 @@
 import React from 'react';
 import TimerDisplay from '../components/TimerDisplay';
 import { useMessages } from '../context/MessagesContext';
+import { useCustomization } from '../context/CustomizationContext';
 
 // Viewer page listens to updates (placeholder without backend)
 const Viewer: React.FC = () => {
   const [time, setTime] = React.useState(0);
+  const duration = 60000;
 
   // Placeholder effect to demonstrate time-of-day
   React.useEffect(() => {
-    const id = setInterval(() => setTime(Date.now() % 60000), 1000);
+    const id = setInterval(() => setTime(Date.now() % duration), 1000);
     return () => clearInterval(id);
-  }, []);
+  }, [duration]);
 
-  const { state } = useMessages();
+  const { state: msgState } = useMessages();
+  const { state } = useCustomization();
+  const progress = time / duration;
 
   return (
-    <div>
-      <TimerDisplay millis={time} />
-      {state.current && <p>{state.current.text}</p>}
+    <div
+      style={{
+        backgroundColor: state.backgroundColor,
+        color: state.themeColor,
+        fontFamily: state.fontFamily,
+        transform: state.mirror ? 'scaleX(-1)' : undefined,
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        textAlign: 'center',
+      }}
+    >
+      {state.showTimer && <TimerDisplay millis={time} />}
+      {state.showMessage && msgState.current && <p>{msgState.current.text}</p>}
+      {state.showProgressBar && (
+        <div
+          style={{
+            width: '80%',
+            height: '10px',
+            background: '#555',
+            marginTop: '1rem',
+          }}
+        >
+          <div
+            style={{
+              width: `${progress * 100}%`,
+              height: '100%',
+              background: state.themeColor,
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add customization context for themes, fonts, backgrounds, and viewer toggles
- include customization panel and apply theme to timer display and viewer
- wrap app with customization provider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b41ec973388328b459e2979aaadb74