### PR TITLE
chore: add firebase deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm install -g firebase-tools
+      - run: npm run build
+      - name: Deploy
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "$FIREBASE_SERVICE_ACCOUNT" > "${HOME}/firebaseServiceAccount.json"
+            export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/firebaseServiceAccount.json"
+            firebase deploy --only hosting
+          elif [ -n "$FIREBASE_TOKEN" ]; then
+            firebase deploy --only hosting --token "$FIREBASE_TOKEN"
+          else
+            echo "Firebase credentials not provided" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for deploying to Firebase Hosting on pushes to `main`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b457edf9388328b988d0873a1573b6