### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests and builds on push and pull_request

## Testing
- `CI=true npm test`
- `npm run build` *(fails: Could not resolve entry module "index.html".)*

------
https://chatgpt.com/codex/tasks/task_e_68b459c9fb088328aec9ccd0c43c47d8