### PR TITLE
Add deployment and packaging scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,9 @@ jobs:
           if [ -n "$FIREBASE_SERVICE_ACCOUNT" ]; then
             echo "$FIREBASE_SERVICE_ACCOUNT" | base64 --decode > "${HOME}/firebaseServiceAccount.json"
             export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/firebaseServiceAccount.json"
-            firebase deploy --only hosting --project "$FIREBASE_PROJECT_ID"
+            npm run deploy -- --project "$FIREBASE_PROJECT_ID"
           elif [ -n "$FIREBASE_TOKEN" ]; then
-            firebase deploy --only hosting --token "$FIREBASE_TOKEN" --project "$FIREBASE_PROJECT_ID"
+            npm run deploy -- --token "$FIREBASE_TOKEN" --project "$FIREBASE_PROJECT_ID"
           else
             echo "Firebase credentials not provided" >&2
             exit 1

--- a/TODO.md
+++ b/TODO.md
@@ -31,4 +31,4 @@
 
 ## Testing & Deployment
 - [x] Unit tests for timer math and state
-- [ ] Firebase Hosting and Electron packaging scripts
+- [x] Firebase Hosting and Electron packaging scripts

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "vite build",
     "test": "jest",
     "api": "node server/index.js",
-    "desktop": "electron ./electron/main.js"
+    "desktop": "electron ./electron/main.js",
+    "deploy": "firebase deploy --only hosting",
+    "package": "electron-packager . StagePulse --platform=linux,win32,darwin --out=dist --overwrite"
   },
   "dependencies": {
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- add npm scripts for Firebase hosting deploy and Electron app packaging
- update deploy workflow to leverage new deploy script
- mark testing & deployment tasks complete in TODO

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b46d54704c83288691a7544cc3eba8